### PR TITLE
Enemies automatically find reference to self

### DIFF
--- a/Assets/Scripts/Enemy/Base Enemy Logic.cs
+++ b/Assets/Scripts/Enemy/Base Enemy Logic.cs
@@ -10,7 +10,6 @@ public class BaseEnemyLogic : MonoBehaviour, Effectable
     [SerializeField] 
     public List<StatusEffects> effects;
     public Collider objectCollider;
-    public GameObject ob;
     public int GoldWorth;
 
     public PlayerStatistics PlayerStatistics;
@@ -58,7 +57,7 @@ public class BaseEnemyLogic : MonoBehaviour, Effectable
         {
             PlayerStatistics.AddMoney(GoldWorth);
             death.playParts(transform);
-            Destroy(ob);
+            Destroy(this.gameObject);
             //subtract present enemies count by 1
             PlayerStatistics.Instance.enemiesPresent--;
             return;

--- a/Assets/Scripts/Enemy/EnemyCarrier.cs
+++ b/Assets/Scripts/Enemy/EnemyCarrier.cs
@@ -25,7 +25,7 @@ public class EnemyCarrier : BaseEnemyLogic
             //subtract present enemies count by 1
             death.playParts(transform);
             PlayerStatistics.Instance.enemiesPresent--;
-            Destroy(ob);
+            Destroy(this.gameObject);
 
             //PlayerStatistics.Instance.AddEnemiesKilled();
             

--- a/Assets/Scripts/Enemy/Fast Enemy.cs
+++ b/Assets/Scripts/Enemy/Fast Enemy.cs
@@ -30,7 +30,7 @@ public class FastEnemy : BaseEnemyLogic
     //         Destroy(gameObject);
     //         Debug.Log("Fast enemy Destroyed");
     //             // Destroy(this.gameObject);
-    //             // Destroy(ob);
+    //             // Destroy(this.gameObject);
     //         //subtract present enemies count by 1
     //         PlayerStatistics.Instance.enemiesPresent--;
     //         return;

--- a/Assets/Scripts/Enemy/Robot Script.cs
+++ b/Assets/Scripts/Enemy/Robot Script.cs
@@ -15,7 +15,7 @@ public class RobotScript : BaseEnemyLogic
         if (health <= 0){
             PlayerStatistics.AddMoney(GoldWorth);
             death.playParts(transform);
-            Destroy(ob);
+            Destroy(this.gameObject);
             //subtract present enemies count by 1
             PlayerStatistics.Instance.enemiesPresent--;
             return;
@@ -24,7 +24,7 @@ public class RobotScript : BaseEnemyLogic
         float healthPercentage = health / maxHealth;
 
         if(healthPercentage < .75 && healthTier1){
-            // Transform firstChild = ob.Find("Robot");
+            // Transform firstChild = this.gameObject.Find("Robot");
             // Transform secondChild = firstChild.Find("Root");
             // Transform thirdChild = secondChild.Find("Body");
             // Transform prey = thirdChild.Find("UpperArm_L");

--- a/Assets/Scripts/Enemy/ScarabScript.cs
+++ b/Assets/Scripts/Enemy/ScarabScript.cs
@@ -11,7 +11,6 @@ public class ScarabScript : BaseEnemyLogic
         if(health<maxHealth)
         {
             health += Time.deltaTime * recoveryRate;
-          
         }
         if(effects.Count > 0)
         {


### PR DESCRIPTION
Changed the base enemy logic script (and subsequent child scripts) to just use this.gameObject to delete themself instead of having to be assigned it via the ob variable in the inspector.