### PR TITLE
Fixed occasionally incorrect tower descriptions

### DIFF
--- a/Assets/Prefabs/UI/Shop/Button Template.prefab
+++ b/Assets/Prefabs/UI/Shop/Button Template.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 8280758802287740588}
   - component: {fileID: 5462788097126248103}
   - component: {fileID: 2082593762618763684}
+  - component: {fileID: 8870266892644560063}
   m_Layer: 5
   m_Name: Button Template
   m_TagString: ShopButton
@@ -129,3 +130,15 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
+--- !u!114 &8870266892644560063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5511344516256347830}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bcbd4e1e0b205fa4e8739f76c6b0b68f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Tower Interaction/DescriptionPanelHover.cs
+++ b/Assets/Scripts/Tower Interaction/DescriptionPanelHover.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class DescriptionPanelHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+{
+    private GameObject descriptionPanel;
+    private string descriptionPanelName;
+
+    private void Start()
+    {
+        descriptionPanelName = name.Substring(0, name.Length - 6) + "Description Panel";
+        descriptionPanel = GameObject.Find(descriptionPanelName);
+    }
+
+    private void Update()
+    {
+        if (descriptionPanel != null)
+        {
+            // Have the tower description panel follow the mouse
+            Vector3 mousePos = Input.mousePosition;
+            Vector2 mousePos2D = new Vector2(mousePos.x, mousePos.y);
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(descriptionPanel.transform.parent.GetComponent<RectTransform>(), mousePos, null, out Vector2 localPoint);
+            descriptionPanel.transform.localPosition = localPoint;
+        }
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        descriptionPanel.transform.GetChild(0).gameObject.SetActive(true);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        descriptionPanel.transform.GetChild(0).gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Tower Interaction/DescriptionPanelHover.cs.meta
+++ b/Assets/Scripts/Tower Interaction/DescriptionPanelHover.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcbd4e1e0b205fa4e8739f76c6b0b68f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tower Interaction/ShopLogic.cs
+++ b/Assets/Scripts/Tower Interaction/ShopLogic.cs
@@ -6,7 +6,7 @@ using UnityEngine.EventSystems;// Required when using Event data.
 using Codice.CM.Common.Tree;
 using System;
 
-public class ShopLogic : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+public class ShopLogic : MonoBehaviour
 {
     [Header("Tower Prefabs")]
     [SerializeField] private GameObject BeeTowerPrefab;
@@ -39,9 +39,7 @@ public class ShopLogic : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
     [SerializeField] private GameObject shopRowTemplate;
     [SerializeField] private GameObject shopButtonTemplate;
     private int numberOfTowersUnlocked;
-    private bool hoveringOnButton = false;
     public GameObject towerDescriptionPanelPrefab;
-    private GameObject activeTowerDescriptionPanel;
     [Header("Scripts")]
     [SerializeField] private TowerPlacement towerPlacement; // Tower placing is handed off to the TowerPlacement script
     private TargetingTypes savedTargettingType;
@@ -54,36 +52,6 @@ public class ShopLogic : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
 
         InitializeShopUI(); // Creates rows and populates them with buttons
     }
-
-    public void OnPointerEnter(PointerEventData eventData)
-    {
-        GameObject hoveredObject = eventData.pointerEnter;
-        //Debug.Log("Hovered object: " + hoveredObject.name);
-        if(hoveredObject.tag == "ShopButton")
-        {
-            //Debug.Log("Hovering on a shop button");
-            hoveringOnButton = true;
-            // Remove the word button from the name to get the tower name
-            String activeTowerDescriptionPanelName = hoveredObject.name;
-            activeTowerDescriptionPanelName = activeTowerDescriptionPanelName.Replace(" Button", " Description Panel");
-            //Debug.Log("Active Tower Description Panel Name: " + activeTowerDescriptionPanelName);
-            // Find the activeTowerDescriptionPanel by name
-            activeTowerDescriptionPanel = GameObject.Find(activeTowerDescriptionPanelName);
-            if(activeTowerDescriptionPanel != null) activeTowerDescriptionPanel.transform.GetChild(0).gameObject.SetActive(true);
-            //else Debug.Log("Active Tower Description Panel not found.");
-        }
-        else
-        {
-            hoveringOnButton = false;
-        }
-    }
-
-    public void OnPointerExit(PointerEventData pointerEventData) //Detect when Cursor leaves the GameObject
-    {
-        hoveringOnButton = false;
-        if(activeTowerDescriptionPanel != null) activeTowerDescriptionPanel.transform.GetChild(0).gameObject.SetActive(false);
-    }
-
 
     void Update()
     {
@@ -100,15 +68,6 @@ public class ShopLogic : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
             {
                 ToggleShopUI();
             }
-        }
-
-        if(hoveringOnButton)
-        {
-            // Have the tower description panel follow the mouse
-            Vector3 mousePos = Input.mousePosition;
-            Vector2 mousePos2D = new Vector2(mousePos.x, mousePos.y);
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(activeTowerDescriptionPanel.transform.parent.GetComponent<RectTransform>(), mousePos, null, out Vector2 localPoint);
-            activeTowerDescriptionPanel.transform.localPosition = localPoint;
         }
     }
 
@@ -137,6 +96,14 @@ public class ShopLogic : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
                     int towerCost = towerChildWithScript.GetComponentInChildren<BaseTowerLogic>().buildCost;
                     string towerDescription = towerChildWithScript.GetComponentInChildren<BaseTowerLogic>().towerDescription;
 
+                    //Create a tower description panel for each button
+                    GameObject newTowerDescriptionPanel = Instantiate(towerDescriptionPanelPrefab, shopPanel.transform);
+                    newTowerDescriptionPanel.name = towerName + " Description Panel";
+                    newTowerDescriptionPanel.transform.GetChild(0).GetChild(0).GetChild(0).GetComponent<TMPro.TextMeshProUGUI>().text = towerName;
+                    newTowerDescriptionPanel.transform.GetChild(0).GetChild(1).GetChild(0).GetComponent<TMPro.TextMeshProUGUI>().text = towerCost.ToString();
+                    newTowerDescriptionPanel.transform.GetChild(0).GetChild(2).GetChild(0).GetComponent<TMPro.TextMeshProUGUI>().text = towerDescription;
+                    newTowerDescriptionPanel.transform.GetChild(0).gameObject.SetActive(false);
+
                     // Create the button, attach it to the row and initialize it
                     GameObject newButton = Instantiate(shopButtonTemplate, newRow.transform);
                     newButton.transform.SetParent(newRow.transform);
@@ -146,14 +113,7 @@ public class ShopLogic : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
                     newButton.GetComponent<RawImage>().texture = towerReference.transform.GetComponentInChildren<BaseTowerLogic>().towerImage;
                     newButton.GetComponent<Button>().onClick.AddListener(delegate {PurchaseTower(towerName); });
 
-                    // Create a tower description panel for each button
-                    GameObject newTowerDescriptionPanel = Instantiate(towerDescriptionPanelPrefab, shopPanel.transform);
-                    newTowerDescriptionPanel.name = towerName + " Description Panel";
-                    //Debug.Log("Description Panel: " + newTowerDescriptionPanel.name);
-                    newTowerDescriptionPanel.transform.GetChild(0).GetChild(0).GetChild(0).GetComponent<TMPro.TextMeshProUGUI>().text = towerName;
-                    newTowerDescriptionPanel.transform.GetChild(0).GetChild(1).GetChild(0).GetComponent<TMPro.TextMeshProUGUI>().text = towerCost.ToString();
-                    newTowerDescriptionPanel.transform.GetChild(0).GetChild(2).GetChild(0).GetComponent<TMPro.TextMeshProUGUI>().text = towerDescription;
-                    newTowerDescriptionPanel.transform.GetChild(0).gameObject.SetActive(false);
+
 
                     towersLeftToSpawn--;
                 }


### PR DESCRIPTION
Fixed the issue where if the user moused over too quickly, the wrong tower description would be shown for the tower (button) that was being hovered over